### PR TITLE
Add symbol colors

### DIFF
--- a/rose_pine.toml
+++ b/rose_pine.toml
@@ -89,7 +89,7 @@
 # "string.special" = ""
 # "string.special.path" = ""
 # "string.special.url" = ""
-# "string.special.symbol" = ""
+"string.special.symbol" = "iris"
 
 "comment" = { fg = "muted", modifiers = ["italic"] }
 # "comment.line" = ""


### PR DESCRIPTION
This PR adds the default string symbol color, for languages like ruby that support it.

### Rose Pine
![image](https://github.com/user-attachments/assets/05cbf716-68b4-43aa-8937-6393be9957b7)
### Rose Pine Dawn
![image](https://github.com/user-attachments/assets/ad30758f-ecbc-41d5-9fa6-b528b9050f4a)
### Rose Pine Moon
![image](https://github.com/user-attachments/assets/f797b7b9-b6ea-455b-8415-3319a52ee0af)
